### PR TITLE
Implement deep copy in ProfileService

### DIFF
--- a/src/server/Modules/PlayerData/ProfileService.lua
+++ b/src/server/Modules/PlayerData/ProfileService.lua
@@ -4,6 +4,18 @@ local Players = game:GetService("Players")
 local dataStore = DataStoreService:GetDataStore("PlayerProfiles")
 local ProfileTemplate = require(script.Parent.ProfileTemplate)
 
+local function deepCopy(t)
+    local copy = {}
+    for k, v in pairs(t) do
+        if type(v) == "table" then
+            copy[k] = deepCopy(v)
+        else
+            copy[k] = v
+        end
+    end
+    return copy
+end
+
 local ProfileService = {}
 
 function ProfileService:LoadProfile(player)
@@ -13,10 +25,12 @@ function ProfileService:LoadProfile(player)
     end)
 
     if not success or not data then
-        data = ProfileTemplate
+        data = deepCopy(ProfileTemplate)
+    else
+        data = deepCopy(data)
     end
 
-    return table.clone(data)
+    return data
 end
 
 function ProfileService:SaveProfile(player, profile)


### PR DESCRIPTION
## Summary
- add `deepCopy` helper that recursively copies tables
- use `deepCopy` for new and existing profiles when loading

## Testing
- `rojo --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841172bb9ec8320b8e835c06fc071c8