### PR TITLE
Fix movement by enabling loadstring

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -10,6 +10,9 @@
     },
 
     "ServerScriptService": {
+      "$properties": {
+        "LoadStringEnabled": true
+      },
       "Server": {
         "$path": "src/server"
       }


### PR DESCRIPTION
## Summary
- enable `LoadStringEnabled` property so movement scripts relying on `loadstring` work

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6841ca8882bc8320ad256a2886aef28d